### PR TITLE
Added attribute for lazy image loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ crossorigin: 'anonymous', // img element crossorigin attr
 alt: '', // img element alt attr
 draggable: true, // img element draggable attr
 disableSrcSet: false, // disable srcSet generation
+loading: 'eager',
 options: {}, // arbitrary imgix options
 
 width: null, // override if you want to hardcode a width into the image

--- a/addon/components/imgix-image.js
+++ b/addon/components/imgix-image.js
@@ -47,6 +47,7 @@ export default Component.extend({
     'alt',
     'crossorigin',
     'draggable',
+    'loading',
     `src:${attributeMap.src}`,
     `placeholderSrc:${attributeMap.src === 'src' ? '_src' : 'src'}`,
     `srcset:${attributeMap.srcset}`,
@@ -61,6 +62,7 @@ export default Component.extend({
   crossorigin: 'anonymous', // img element crossorigin attr
   alt: '', // img element alt attr
   draggable: true, // img element draggable attr
+  loading: 'eager', // eager or lazy
   options: {}, // arbitrary imgix options
   disableLibraryParam: false,
 

--- a/tests/integration/components/imgix-image-test.js
+++ b/tests/integration/components/imgix-image-test.js
@@ -219,6 +219,14 @@ module('Integration | Component | imgix image', function(hooks) {
     assert.equal(this.$('img').attr('draggable'), 'false');
   });
 
+  test('attribute bindings: the loading argument will set the loading attribute on the image element', async function(assert) {
+    await render(
+      hbs`<div style='width:1250px;height:200px;'>{{imgix-image path='/users/1.png' loading='lazy'}}</div>`
+    );
+
+    assert.equal(this.$('img').attr('loading'), 'lazy');
+  });
+
   test('attribute bindings: the crossorigin argument will set the crossorigin attribute on the image element', async function(assert) {
     assert.expect(1);
 


### PR DESCRIPTION
Adds the `loading` attribute to imgix-image components. Can be eager or lazy, defaults to eager. Tested locally and it works great in Chrome & FF, no effect in Safari.

https://caniuse.com/loading-lazy-attr